### PR TITLE
Multiple UX/UI Improvements

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -18,5 +18,5 @@ public static class Globals
 
     public static readonly string appOriginPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
-    public const string timeFormat = @"hh\:mm\:ss";
+    public const string timeFormat = @"hh\:mm\:ss\:ff";
 }

--- a/Globals.cs
+++ b/Globals.cs
@@ -18,4 +18,5 @@ public static class Globals
 
     public static readonly string appOriginPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
+    public const string timeFormat = @"hh\:mm\:ss";
 }

--- a/Globals.cs
+++ b/Globals.cs
@@ -8,10 +8,10 @@ public static class Globals
     public const string company = "Rendeer";
     public const string copyright = "Copyright © Rendeer 2021";
 
-    private const string majorVersion = "1";
+    private const string majorVersion = "2";
     private const string minorVersion = "0";
     private const string releaseVersion = "0";
-    private const string buildDate = "211026";
+    private const string buildDate = "220220";
 
     public const string assemblyVersion = majorVersion + "." + minorVersion + "." + releaseVersion + ".0";
     public const string customVersion = majorVersion + "." + minorVersion + "." + releaseVersion + "." + buildDate;

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,13 +5,13 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:VideoTrimmer"
         mc:Ignorable="d"
-        Title="Video Trimmer" Height="633" Width="430" ResizeMode="NoResize" Background="#FF212121" DragEnter="Window_DragEnter" DragLeave="Window_DragLeave" Drop="Window_DragDrop" AllowDrop="True" MouseDown="ClearKeyboardFocus">
+        Title="Video Trimmer" Height="770" Width="708" ResizeMode="NoResize" Background="#FF212121" DragEnter="Window_DragEnter" DragLeave="Window_DragLeave" Drop="Window_DragDrop" AllowDrop="True" MouseDown="ClearKeyboardFocus">
     <Grid Margin="30,20" MouseDown="ClearKeyboardFocus">
         <Grid.RowDefinitions>
-            <RowDefinition Height="35"/>
-            <RowDefinition Height="320"/>
             <RowDefinition Height="33"/>
-            <RowDefinition Height="33"/>
+            <RowDefinition Height="415"/>
+            <RowDefinition Height="50"/>
+            <RowDefinition Height="50"/>
             <RowDefinition />
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
@@ -22,45 +22,45 @@
         </Grid.ColumnDefinitions>
 
         <!-- file info row -->
-        <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" Height="35">
+        <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" Height="35" Margin="0,-1,0,414" Grid.RowSpan="2">
             <Button Content="Select video" Width="90" Click="ButtonFileOpen_Click" Margin="0,0,0,10" Height="25" BorderBrush="{x:Null}" FontSize="14" Template="{DynamicResource FilePickerButtonTemplate}"/>
             <Label Name="fileNameLabel" Content="No video selected" Margin="10,-2,0,10" Foreground="White" HorizontalAlignment="Left" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Disabled" AutomationProperties.IsOffscreenBehavior="Onscreen" ToolTip="No video selected" FontSize="14" UseLayoutRounding="False"/>
         </StackPanel>
 
         <!-- video player -->
         <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Orientation="Vertical" Grid.RowSpan="2">
-            <MediaElement x:Name="MediaPlayer" Height="275" VerticalAlignment="Center" Width="360" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayerOnMediaOpened" Margin="0,0,0,5" />
-            <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="18" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
-            <StackPanel Orientation="Horizontal">
-                <Slider x:Name="TimelineSlider" Margin="0" VerticalAlignment="Top" Height="22" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" Width="364" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1" IsSelectionRangeEnabled="True"/>
+            <MediaElement x:Name="MediaPlayer" Height="360" VerticalAlignment="Center" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayerOnMediaOpened" Margin="0" Width="640" />
+            <StackPanel>
+                <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
+                <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="32" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             </StackPanel>
         </StackPanel>
 
         <!-- timecode inputs row -->
-        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center">
-            <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" Margin="0" />
-            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" Width="140" LostFocus="Timecode_LostFocus" MaxLength="10" MaxLines="1" FontSize="18" Margin="0,3,10,2" HorizontalAlignment="Left" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,1" HorizontalAlignment="Right" Width="127">
+            <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Click="OnTimecodePickButtonClicked" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" Margin="0" />
+            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="10" MaxLines="1" FontSize="24" Margin="0" HorizontalAlignment="Right" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
         </StackPanel>
         <!--<Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />-->
         <Grid Grid.Column="1" Grid.Row="2" Margin="0">
             <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button x:Name="jumpToStartMarkerButton" Content="⬅" VerticalAlignment="Center" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to start marker" />
-                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18"  />
-                <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to end marker" />
+                <Button x:Name="jumpToStartMarkerButton" Content="⬅" VerticalAlignment="Center" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to start marker" />
+                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32"  />
+                <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to end marker" />
             </StackPanel>
         </Grid>
-        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Width="110">
-            <TextBox x:Name="timecodeEnd" IsEnabled="False" Height="20" Text="00:00:00" Width="86"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="18" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="10,3,0,2" VerticalAlignment="Center" Padding="0,-2,0,0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
-            <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" />
+        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left" Width="127">
+            <TextBox x:Name="timecodeEnd" IsEnabled="False" Text="00:00:00"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="24" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="0" VerticalAlignment="Center" Padding="0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
+            <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" />
         </StackPanel>
         <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Grid.ColumnSpan="3">
             <CheckBox Name="pauseAtEndMarker" ToolTipService.ShowOnDisabled="True" Content="Pause at end marker" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Automatically pause when the end marker is reached." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" Foreground="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"/>
         </StackPanel>
 
-        <Separator Grid.ColumnSpan="3" Height="2" Margin="0,6,0,0" Grid.Row="4" VerticalAlignment="Top"/>
+        <Separator Grid.ColumnSpan="3" Margin="0,6,0,0" Grid.Row="4" VerticalAlignment="Top"/>
 
         <!-- options -->
-        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" VerticalAlignment="Center" Margin="0,12,0,25">
+        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" VerticalAlignment="Bottom" Margin="0,0,0,25" Height="56">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type CheckBox}">
                     <Setter Property="Foreground" Value="White"/>
@@ -74,7 +74,7 @@
             <CheckBox Name="removeAudio" ToolTipService.ShowOnDisabled="True" Content="Remove audio" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="The output video will not contain any audio streams." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}"/>
             <CheckBox Name="recompressFile" ToolTipService.ShowOnDisabled="True" Content="Recompress file" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Trimming will take significantly more time, but will offer greater precision while trimming." Checked="RecompressFile_ValueChanged" Unchecked="RecompressFile_ValueChanged" FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" />
         </StackPanel>
-        <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="4" VerticalAlignment="Center" Orientation="Horizontal" Margin="0,26,0,39" HorizontalAlignment="Right" Height="28" Width="217">
+        <StackPanel Grid.Column="1" Grid.Row="4" VerticalAlignment="Bottom" Orientation="Horizontal" Margin="0,0,0,39" HorizontalAlignment="Right" Height="28" Width="217" Grid.ColumnSpan="2">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type Label}">
                     <Setter Property="Foreground" Value="White"/>
@@ -92,7 +92,7 @@
 
         <!-- trim video button + about -->
         <Button Name="trimVideoButton" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="5" Content="TRIM VIDEO" VerticalAlignment="Top" Click="ButtonTrimVideo_Click" Height="25" BorderBrush="{x:Null}" IsEnabled="False" UseLayoutRounding="False" FontSize="14" FontWeight="Bold" Template="{DynamicResource PrimaryActionButtonTemplate}" />
-        <Label Name="aboutFooter" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="5" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10" Height="23"/>
+        <Label Name="aboutFooter" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="5" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10" Height="23"/>
 
         <!-- The currently unused "About" button -->
         <!--<Button Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="2" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="42" Foreground="#19FFFFFF" FontSize="10" Cursor="Hand" Background="{x:Null}" BorderBrush="{x:Null}" Click="ButtonShowAbout_Click" />-->

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -29,9 +29,9 @@
 
         <!-- video player -->
         <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Orientation="Vertical" Grid.RowSpan="2">
-            <MediaElement x:Name="MediaPlayer" Height="360" VerticalAlignment="Center" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayerOnMediaOpened" Margin="0" Width="640" />
+            <MediaElement x:Name="MediaPlayer" Height="360" VerticalAlignment="Center" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayer_OnMediaOpened" Margin="0" Width="640" />
             <StackPanel>
-                <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
+                <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="SliderValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
                 <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="32" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             </StackPanel>
         </StackPanel>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -29,19 +29,26 @@
         <!-- video player -->
         <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Orientation="Vertical" Grid.RowSpan="2">
             <MediaElement x:Name="MediaPlayer" Height="275" VerticalAlignment="Center" Width="360" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayerOnMediaOpened" Margin="0,0,0,5" />
-            <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" Width="201" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="18" Margin="0,1,10,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
+            <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="18" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="TimelineSlider" Margin="0" VerticalAlignment="Top" Height="22" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" Width="355" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1"/>
+                <Slider x:Name="TimelineSlider" Margin="0" VerticalAlignment="Top" Height="22" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" Width="364" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1" IsSelectionRangeEnabled="True"/>
             </StackPanel>
         </StackPanel>
 
         <!-- timecode inputs row -->
-        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Top" Height="25">
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center">
             <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" Margin="0" />
             <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" Width="140" LostFocus="Timecode_LostFocus" MaxLength="10" MaxLines="1" FontSize="18" Margin="0,3,10,2" HorizontalAlignment="Left" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
         </StackPanel>
-        <Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />
-        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" Height="25" Width="110">
+        <!--<Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />-->
+        <Grid Grid.Column="1" Grid.Row="2" Margin="0">
+            <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center">
+                <Button x:Name="jumpToStartMarkerButton" Content="⏪︎" VerticalAlignment="Center" Height="25" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to start marker" />
+                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18"  />
+                <Button x:Name="jumpToEndMarkerButton" Content="⏭︎" VerticalAlignment="Center" Height="25" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to end marker" />
+            </StackPanel>
+        </Grid>
+        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Width="110">
             <TextBox x:Name="timecodeEnd" IsEnabled="False" Height="20" Text="00:00:00" Width="86"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="18" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="10,3,0,2" VerticalAlignment="Center" Padding="0,-2,0,0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
             <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" />
         </StackPanel>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -9,8 +9,8 @@
     <Grid Margin="30,20" MouseDown="ClearKeyboardFocus">
         <Grid.RowDefinitions>
             <RowDefinition Height="35"/>
-            <RowDefinition Height="300"/>
-            <RowDefinition Height="30"/>
+            <RowDefinition Height="320"/>
+            <RowDefinition Height="33"/>
             <RowDefinition />
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
@@ -21,7 +21,7 @@
         </Grid.ColumnDefinitions>
 
         <!-- file info row -->
-        <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center">
+        <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" Height="35">
             <Button Content="Select video" Width="90" Click="ButtonFileOpen_Click" Margin="0,0,0,10" Height="25" BorderBrush="{x:Null}" FontSize="14" Template="{DynamicResource FilePickerButtonTemplate}"/>
             <Label Name="fileNameLabel" Content="No video selected" Margin="10,-2,0,10" Foreground="White" HorizontalAlignment="Left" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Disabled" AutomationProperties.IsOffscreenBehavior="Onscreen" ToolTip="No video selected" FontSize="14" UseLayoutRounding="False"/>
         </StackPanel>
@@ -29,25 +29,26 @@
         <!-- video player -->
         <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Orientation="Vertical" Grid.RowSpan="2">
             <MediaElement x:Name="MediaPlayer" Height="275" VerticalAlignment="Center" Width="360" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayerOnMediaOpened" Margin="0,0,0,5" />
+            <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" Width="201" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="18" Margin="0,1,10,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="TimelineSlider" Margin="0" VerticalAlignment="Top" Height="22" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" Width="355" HorizontalContentAlignment="Stretch" />
+                <Slider x:Name="TimelineSlider" Margin="0" VerticalAlignment="Top" Height="22" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" Width="355" HorizontalContentAlignment="Stretch" ValueChanged="TimelineSlider_ValueChanged" Value="-1"/>
             </StackPanel>
         </StackPanel>
 
         <!-- timecode inputs row -->
-        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Top">
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Top" Height="25">
             <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" Margin="0" />
-            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" Width="80" LostFocus="Timecode_LostFocus" MaxLength="8" MaxLines="1" FontSize="18" Margin="0,1,10,0" HorizontalAlignment="Left" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
+            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" Width="140" LostFocus="Timecode_LostFocus" MaxLength="10" MaxLines="1" FontSize="18" Margin="0,3,10,2" HorizontalAlignment="Left" BorderBrush="{x:Null}" VerticalAlignment="Center" Height="20" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
         </StackPanel>
-        <Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Width="22" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" />
-        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
-            <TextBox Name="timecodeEnd" IsEnabled="False" Height="20" Text="00:00:00" Width="80"  LostFocus="Timecode_LostFocus" TextAlignment="Right" MaxLength="8" MaxLines="1" FontSize="18" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="10,1,0,0" VerticalAlignment="Center" Padding="0,-2,0,0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
+        <Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />
+        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" Height="25" Width="110">
+            <TextBox x:Name="timecodeEnd" IsEnabled="False" Height="20" Text="00:00:00" Width="86"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="18" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="10,3,0,2" VerticalAlignment="Center" Padding="0,-2,0,0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
             <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" />
         </StackPanel>
         <Separator Grid.ColumnSpan="3" Height="2" Margin="0,6,0,0" Grid.Row="3" VerticalAlignment="Top"/>
 
         <!-- options -->
-        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3" VerticalAlignment="Center" Margin="0,33,0,27">
+        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3" VerticalAlignment="Center" Margin="0,12,0,25" Height="56">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type CheckBox}">
                     <Setter Property="Foreground" Value="White"/>
@@ -61,7 +62,7 @@
             <CheckBox Name="removeAudio" ToolTipService.ShowOnDisabled="True" Content="Remove audio" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="The output video will not contain any audio streams." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}"/>
             <CheckBox Name="recompressFile" ToolTipService.ShowOnDisabled="True" Content="Recompress file" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Trimming will take significantly more time, but will offer greater precision while trimming." Checked="RecompressFile_ValueChanged" Unchecked="RecompressFile_ValueChanged" FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" />
         </StackPanel>
-        <StackPanel Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="3" VerticalAlignment="Center" Orientation="Horizontal" Margin="0,47,0,41" HorizontalAlignment="Right">
+        <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="3" VerticalAlignment="Center" Orientation="Horizontal" Margin="0,26,0,39" HorizontalAlignment="Right" Height="28" Width="217">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type Label}">
                     <Setter Property="Foreground" Value="White"/>
@@ -79,7 +80,7 @@
 
         <!-- trim video button + about -->
         <Button Name="trimVideoButton" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" Content="TRIM VIDEO" VerticalAlignment="Top" Click="ButtonTrimVideo_Click" Height="25" BorderBrush="{x:Null}" IsEnabled="False" UseLayoutRounding="False" FontSize="14" FontWeight="Bold" Template="{DynamicResource PrimaryActionButtonTemplate}" />
-        <Label Name="aboutFooter" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10"/>
+        <Label Name="aboutFooter" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10" Height="23"/>
 
         <!-- The currently unused "About" button -->
         <!--<Button Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="2" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="42" Foreground="#19FFFFFF" FontSize="10" Cursor="Hand" Background="{x:Null}" BorderBrush="{x:Null}" Click="ButtonShowAbout_Click" />-->

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -31,7 +31,7 @@
         <StackPanel Grid.ColumnSpan="3" Grid.Column="0" Grid.Row="1" Orientation="Vertical" Grid.RowSpan="2">
             <MediaElement x:Name="MediaPlayer" Height="360" VerticalAlignment="Center" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayer_OnMediaOpened" Margin="0" Width="640" />
             <StackPanel>
-                <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="SliderValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
+                <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="Slider_ValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
                 <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" MaxLength="12" MaxLines="1" FontSize="32" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             </StackPanel>
         </StackPanel>
@@ -44,9 +44,9 @@
         <!--<Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />-->
         <Grid Grid.Column="1" Grid.Row="2" Margin="0">
             <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button x:Name="jumpToStartMarkerButton" Content="⬅" VerticalAlignment="Center" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to start marker" />
-                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32"  />
-                <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to end marker" />
+                <Button x:Name="jumpToStartMarkerButton" Content="⬅" VerticalAlignment="Center" Click="JumpToStartMarker_ButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to start marker" />
+                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Click="PlayPause_ButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32"  />
+                <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="JumpToEndMarker_ButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to end marker" />
             </StackPanel>
         </Grid>
         <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,11 +5,12 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:VideoTrimmer"
         mc:Ignorable="d"
-        Title="Video Trimmer" Height="600" Width="430" ResizeMode="NoResize" Background="#FF212121" DragEnter="Window_DragEnter" DragLeave="Window_DragLeave" Drop="Window_DragDrop" AllowDrop="True" MouseDown="ClearKeyboardFocus">
+        Title="Video Trimmer" Height="633" Width="430" ResizeMode="NoResize" Background="#FF212121" DragEnter="Window_DragEnter" DragLeave="Window_DragLeave" Drop="Window_DragDrop" AllowDrop="True" MouseDown="ClearKeyboardFocus">
     <Grid Margin="30,20" MouseDown="ClearKeyboardFocus">
         <Grid.RowDefinitions>
             <RowDefinition Height="35"/>
             <RowDefinition Height="320"/>
+            <RowDefinition Height="33"/>
             <RowDefinition Height="33"/>
             <RowDefinition />
             <RowDefinition Height="50"/>
@@ -52,10 +53,14 @@
             <TextBox x:Name="timecodeEnd" IsEnabled="False" Height="20" Text="00:00:00" Width="86"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="18" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="10,3,0,2" VerticalAlignment="Center" Padding="0,-2,0,0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
             <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Width="20" Height="25" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="18" />
         </StackPanel>
-        <Separator Grid.ColumnSpan="3" Height="2" Margin="0,6,0,0" Grid.Row="3" VerticalAlignment="Top"/>
+        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Grid.ColumnSpan="3">
+            <CheckBox Name="pauseAtEndMarker" ToolTipService.ShowOnDisabled="True" Content="Pause at end marker" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Automatically pause when the end marker is reached." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" Foreground="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"/>
+        </StackPanel>
+
+        <Separator Grid.ColumnSpan="3" Height="2" Margin="0,6,0,0" Grid.Row="4" VerticalAlignment="Top"/>
 
         <!-- options -->
-        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3" VerticalAlignment="Center" Margin="0,12,0,25" Height="56">
+        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" VerticalAlignment="Center" Margin="0,12,0,25">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type CheckBox}">
                     <Setter Property="Foreground" Value="White"/>
@@ -69,7 +74,7 @@
             <CheckBox Name="removeAudio" ToolTipService.ShowOnDisabled="True" Content="Remove audio" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="The output video will not contain any audio streams." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}"/>
             <CheckBox Name="recompressFile" ToolTipService.ShowOnDisabled="True" Content="Recompress file" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Trimming will take significantly more time, but will offer greater precision while trimming." Checked="RecompressFile_ValueChanged" Unchecked="RecompressFile_ValueChanged" FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" />
         </StackPanel>
-        <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="3" VerticalAlignment="Center" Orientation="Horizontal" Margin="0,26,0,39" HorizontalAlignment="Right" Height="28" Width="217">
+        <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="4" VerticalAlignment="Center" Orientation="Horizontal" Margin="0,26,0,39" HorizontalAlignment="Right" Height="28" Width="217">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type Label}">
                     <Setter Property="Foreground" Value="White"/>
@@ -86,8 +91,8 @@
         </StackPanel>
 
         <!-- trim video button + about -->
-        <Button Name="trimVideoButton" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" Content="TRIM VIDEO" VerticalAlignment="Top" Click="ButtonTrimVideo_Click" Height="25" BorderBrush="{x:Null}" IsEnabled="False" UseLayoutRounding="False" FontSize="14" FontWeight="Bold" Template="{DynamicResource PrimaryActionButtonTemplate}" />
-        <Label Name="aboutFooter" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="4" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10" Height="23"/>
+        <Button Name="trimVideoButton" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="5" Content="TRIM VIDEO" VerticalAlignment="Top" Click="ButtonTrimVideo_Click" Height="25" BorderBrush="{x:Null}" IsEnabled="False" UseLayoutRounding="False" FontSize="14" FontWeight="Bold" Template="{DynamicResource PrimaryActionButtonTemplate}" />
+        <Label Name="aboutFooter" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="5" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="281" Foreground="#26FFFFFF" Background="{x:Null}" BorderBrush="{x:Null}" HorizontalContentAlignment="Right" FontSize="10" Height="23"/>
 
         <!-- The currently unused "About" button -->
         <!--<Button Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="2" Content="About" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="42" Foreground="#19FFFFFF" FontSize="10" Cursor="Hand" Background="{x:Null}" BorderBrush="{x:Null}" Click="ButtonShowAbout_Click" />-->

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -44,9 +44,9 @@
         <!--<Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />-->
         <Grid Grid.Column="1" Grid.Row="2" Margin="0">
             <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button x:Name="jumpToStartMarkerButton" Content="⏪︎" VerticalAlignment="Center" Height="25" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to start marker" />
-                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18"  />
-                <Button x:Name="jumpToEndMarkerButton" Content="⏭︎" VerticalAlignment="Center" Height="25" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to end marker" />
+                <Button x:Name="jumpToStartMarkerButton" Content="⬅" VerticalAlignment="Center" Click="OnJumpToStartMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to start marker" />
+                <Button x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Center" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18"  />
+                <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" ToolTip="Go to end marker" />
             </StackPanel>
         </Grid>
         <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Width="110">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -32,14 +32,14 @@
             <MediaElement x:Name="MediaPlayer" Height="360" VerticalAlignment="Center" LoadedBehavior="Manual" ScrubbingEnabled="True" MediaOpened="MediaPlayer_OnMediaOpened" Margin="0" Width="640" />
             <StackPanel>
                 <Slider x:Name="TimelineSlider" Margin="0" ScrollViewer.VerticalScrollBarVisibility="Disabled"  IsEnabled="False" HorizontalContentAlignment="Stretch" ValueChanged="SliderValueChanged" Value="-1" IsSelectionRangeEnabled="True" VerticalAlignment="Top"/>
-                <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="12" MaxLines="1" FontSize="32" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
+                <TextBox x:Name="timecodeCurrent" IsEnabled="False" Text="00:00:00" MaxLength="12" MaxLines="1" FontSize="32" Margin="0,1,0,0" HorizontalAlignment="Center" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0,-2,0,0" Template="{DynamicResource HyperlinkTextBoxTemplate}" TextAlignment="Center" />
             </StackPanel>
         </StackPanel>
 
         <!-- timecode inputs row -->
-        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,1" HorizontalAlignment="Right" Width="127">
-            <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Click="OnTimecodePickButtonClicked" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" Margin="0" />
-            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00" LostFocus="Timecode_LostFocus" MaxLength="10" MaxLines="1" FontSize="24" Margin="0" HorizontalAlignment="Right" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0" Template="{DynamicResource HyperlinkTextBoxTemplate}" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0" HorizontalAlignment="Right">
+            <Button ToolTip="Use current position of the video player as Start timecode" x:Name="StartTimecodePickButton" Content="◢" VerticalAlignment="Center" Click="Timecode_PickButtonPressed" IsEnabled="False" Tag="Start" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" Margin="0" />
+            <TextBox x:Name="timecodeStart" IsEnabled="False" Text="00:00:00:00" LostFocus="Timecode_LostFocus" KeyDown="Timecode_KeyDown" MaxLength="10" MaxLines="1" FontSize="24" Margin="0" HorizontalAlignment="Right" BorderBrush="{x:Null}" VerticalAlignment="Center" Padding="0" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
         </StackPanel>
         <!--<Button Grid.Column="1" Grid.Row="2"  x:Name="PlayPauseButton" Content="▶" VerticalAlignment="Top" Height="25" Click="OnPlayPauseButtonClicked" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="18" Margin="50,0" />-->
         <Grid Grid.Column="1" Grid.Row="2" Margin="0">
@@ -49,9 +49,9 @@
                 <Button x:Name="jumpToEndMarkerButton" Content="⮕" VerticalAlignment="Center" Click="OnJumpToEndMarkerButtonPressed" IsEnabled="False" Template="{DynamicResource HyperlinkButtonTemplate}" Background="{x:Null}" BorderBrush="{x:Null}" FontSize="32" ToolTip="Go to end marker" />
             </StackPanel>
         </Grid>
-        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left" Width="127">
-            <TextBox x:Name="timecodeEnd" IsEnabled="False" Text="00:00:00"  LostFocus="Timecode_LostFocus" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="24" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="0" VerticalAlignment="Center" Padding="0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
-            <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Click="OnTimecodePickButtonClicked" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" />
+        <StackPanel Grid.Column="2" Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Left">
+            <TextBox x:Name="timecodeEnd" IsEnabled="False" Text="00:00:00:00"  LostFocus="Timecode_LostFocus" KeyDown="Timecode_KeyDown" TextAlignment="Left" MaxLength="10" MaxLines="1" FontSize="24" HorizontalAlignment="Right" BorderBrush="{x:Null}" Margin="0" VerticalAlignment="Center" Padding="0" HorizontalContentAlignment="Right" Template="{DynamicResource HyperlinkTextBoxTemplate}"/>
+            <Button ToolTip="Use current position of the video player as End timecode" x:Name="EndTimecodePickButton" Content="◣" VerticalAlignment="Center" Click="Timecode_PickButtonPressed" IsEnabled="False" Margin="0" Tag="End" Background="{x:Null}" BorderBrush="{x:Null}" Template="{DynamicResource HyperlinkButtonTemplate}" FontSize="24" />
         </StackPanel>
         <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Grid.ColumnSpan="3">
             <CheckBox Name="pauseAtEndMarker" ToolTipService.ShowOnDisabled="True" Content="Pause at end marker" IsEnabled="False" VerticalContentAlignment="Center" Margin="0,5" ToolTip="Automatically pause when the end marker is reached." FontSize="14" Template="{DynamicResource CheckBoxControlTemplate}" Foreground="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -50,6 +50,8 @@ namespace VideoTrimmer
             // Create wrapper classes for Start and End markers
             timeMarkerStart = new TimeCodeWrapper(timecodeStart, StartTimecodePickButton, jumpToStartMarkerButton, true);
             timeMarkerEnd = new TimeCodeWrapper(timecodeEnd, EndTimecodePickButton, jumpToEndMarkerButton, false);
+
+            timecodeCurrent.Text = GetStringFromTimeSpan(null);
         }
 
         // Used to enable or disable editable fields
@@ -210,13 +212,6 @@ namespace VideoTrimmer
             // if everything failed -- undo editing field
             _ = Dispatcher.BeginInvoke(new Action(() => timeMarker.TextBox.Undo()));
             System.Media.SystemSounds.Asterisk.Play();
-        }
-
-        // handles value change in timecode text boxes
-        private void Timecode_LostFocus(object sender, RoutedEventArgs e)
-        {
-            System.Windows.Controls.TextBox senderTextBox = (System.Windows.Controls.TextBox)sender;
-            ValidateTimeMarker(senderTextBox == timeMarkerStart.TextBox ? timeMarkerStart : timeMarkerEnd);
         }
 
         // validates values in the DesiredFileSize text box
@@ -430,7 +425,7 @@ namespace VideoTrimmer
         }
 
         // User wants to use current position of the video player as the Start or End timecode
-        private void OnTimecodePickButtonClicked(object sender, RoutedEventArgs e)
+        private void Timecode_PickButtonPressed(object sender, RoutedEventArgs e)
         {
             System.Windows.Controls.Button senderButton = (System.Windows.Controls.Button)sender;
 
@@ -441,6 +436,23 @@ namespace VideoTrimmer
             // get current media position and set it
             if (IsTimeSpanValid(newTimeSpan, timeMarkerToUpdate.IsStartMarker))
                 timeMarkerToUpdate.SetTimeSpan(newTimeSpan);
+        }
+
+        private void Timecode_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Return)
+            {
+                System.Windows.Controls.TextBox senderTextBox = (System.Windows.Controls.TextBox)sender;
+                ValidateTimeMarker(senderTextBox == timeMarkerStart.TextBox ? timeMarkerStart : timeMarkerEnd);
+                Keyboard.ClearFocus();
+            }
+        }
+
+        // handles value change in timecode text boxes
+        private void Timecode_LostFocus(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Controls.TextBox senderTextBox = (System.Windows.Controls.TextBox)sender;
+            ValidateTimeMarker(senderTextBox == timeMarkerStart.TextBox ? timeMarkerStart : timeMarkerEnd);
         }
 
         // User clicked on the slider, so let's disable automatic slider updates

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,41 +8,6 @@ using Path = System.IO.Path;
 
 namespace VideoTrimmer
 {
-    public class TimeCodeWrapper
-    {
-        public bool IsStartMarker { get; private set; }
-        public System.Windows.Controls.TextBox TextBox { get; private set; }
-        public System.Windows.Controls.Button ButtonSet { get; private set; }
-        public System.Windows.Controls.Button ButtonJumpTo { get; private set; }
-        public TimeSpan? CurrentTime { get; private set; }
-
-        public TimeCodeWrapper(System.Windows.Controls.TextBox textBox, System.Windows.Controls.Button buttonSet, System.Windows.Controls.Button buttonJumpTo, bool isStartMarker)
-        {
-            TextBox = textBox;
-            ButtonSet = buttonSet;
-            ButtonJumpTo = buttonJumpTo;
-            IsStartMarker = isStartMarker;
-
-            SetTimeSpan(null);
-        }
-
-        public void SetTimeSpan(TimeSpan? timeSpan)
-        {
-            CurrentTime = timeSpan;
-            TextBox.Text = CurrentTime.HasValue ? CurrentTime.Value.ToString(Globals.timeFormat) : "N/A";
-            ButtonSet.IsEnabled = CurrentTime.HasValue;
-            ButtonJumpTo.IsEnabled = CurrentTime.HasValue;
-        }
-
-        public void SetLockStatus(bool newLockStatus)
-        {
-            TextBox.IsEnabled = newLockStatus;
-            ButtonSet.IsEnabled = newLockStatus;
-            ButtonJumpTo.IsEnabled = !newLockStatus;
-            CurrentTime = null;
-        }
-    }
-
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -52,6 +52,7 @@ namespace VideoTrimmer
             timecodeEnd.IsEnabled = NewLockStatus;
             removeAudio.IsEnabled = NewLockStatus;
             recompressFile.IsEnabled = NewLockStatus;
+            pauseAtEndMarker.IsEnabled = NewLockStatus;
             jumpToStartMarkerButton.IsEnabled = NewLockStatus == false;
             jumpToEndMarkerButton.IsEnabled = NewLockStatus == false;
             PlayPauseButton.IsEnabled = NewLockStatus;
@@ -373,7 +374,15 @@ namespace VideoTrimmer
         private void MediaPlayerOnTimeChanged(object sender, EventArgs e)
         {
             if (SliderUpdatesPossible) TimelineSlider.Value = mediaPlayerClock.CurrentTime.Value.TotalMilliseconds;
+
             UpdateCurrentTimeText(mediaPlayerClock.CurrentTime);
+
+            if (pauseAtEndMarker.IsChecked.HasValue && pauseAtEndMarker.IsChecked.Value && mediaPlayerClock.CurrentTime.Value >= TimeSpan.Parse(timecodeEnd.Text))
+                    mediaPlayerClock.Controller.Pause();
+
+            bool videoEnd = mediaPlayerClock.NaturalDuration == mediaPlayerClock.CurrentTime;
+
+            PlayPauseButton.Content = mediaPlayerClock.IsPaused || videoEnd ? "▶" : "❚❚";
         }
 
         // User interaction - button clicked
@@ -407,12 +416,10 @@ namespace VideoTrimmer
 
                 if (mediaPlayerClock.IsPaused || videoEnd)
                 {
-                    PlayPauseButton.Content = "❚❚";
                     mediaPlayerClock.Controller.Resume();
                 }
                 else
                 {
-                    PlayPauseButton.Content = "▶";
                     mediaPlayerClock.Controller.Pause();
                 }
             }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace VideoTrimmer
             timeMarkerStart = new TimeCodeWrapper(timecodeStart, StartTimecodePickButton, jumpToStartMarkerButton, true);
             timeMarkerEnd = new TimeCodeWrapper(timecodeEnd, EndTimecodePickButton, jumpToEndMarkerButton, false);
 
-            timecodeCurrent.Text = GetStringFromTimeSpan(null);
+            timecodeCurrent.Text = GetStringFromTimeSpan(TimeSpan.Zero);
         }
 
         // Used to enable or disable editable fields
@@ -91,8 +91,8 @@ namespace VideoTrimmer
         {
             fileNameLabel.Content = "No video selected";
             fileNameLabel.ToolTip = "No video selected";
-            timecodeStart.Text = GetStringFromTimeSpan(TimeSpan.FromSeconds(0.0));
-            timecodeEnd.Text = GetStringFromTimeSpan(TimeSpan.FromSeconds(0.0));
+            timecodeStart.Text = GetStringFromTimeSpan(TimeSpan.Zero);
+            timecodeEnd.Text = GetStringFromTimeSpan(TimeSpan.Zero);
             videoProcessing = new VideoProcessing();
             SetFieldsLockStatus(false);
 
@@ -116,7 +116,7 @@ namespace VideoTrimmer
             SetFieldsLockStatus(true);
 
             // Get video duration and paste it into "End" timecode TextBox
-            timecodeStart.Text = GetStringFromTimeSpan(TimeSpan.FromSeconds(0.0));
+            timecodeStart.Text = GetStringFromTimeSpan(TimeSpan.Zero);
             timecodeEnd.Text = GetStringFromTimeSpan(videoProcessing.GetDuration());
 
             if (mediaPlayerClock != null)
@@ -435,7 +435,13 @@ namespace VideoTrimmer
 
             // get current media position and set it
             if (IsTimeSpanValid(newTimeSpan, timeMarkerToUpdate.IsStartMarker))
+            {
                 timeMarkerToUpdate.SetTimeSpan(newTimeSpan);
+            }
+            else
+            {
+                System.Media.SystemSounds.Asterisk.Play();
+            }
         }
 
         private void Timecode_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -121,8 +121,8 @@ namespace VideoTrimmer
 
             if (mediaPlayerClock != null)
             {
-                mediaPlayerClock.CurrentTimeInvalidated -= MediaPlayer_OnTimeChanged;
-                mediaPlayerClock.CurrentGlobalSpeedInvalidated -= MediaPlayer_OnTimeChanged;
+                mediaPlayerClock.CurrentTimeInvalidated -= MediaPlayer_TimeChanged;
+                mediaPlayerClock.CurrentGlobalSpeedInvalidated -= MediaPlayer_TimeChanged;
             }
 
             cachedMediaVolume = MediaPlayer.Volume;
@@ -133,14 +133,14 @@ namespace VideoTrimmer
 
             // If either of these callbacks are called, call the same function.
             // CurrentTimeInvalidate isn't always called when the video is paused, so we need the other callback as well.
-            mediaPlayerClock.CurrentTimeInvalidated += MediaPlayer_OnTimeChanged;
-            mediaPlayerClock.CurrentGlobalSpeedInvalidated += MediaPlayer_OnTimeChanged;
+            mediaPlayerClock.CurrentTimeInvalidated += MediaPlayer_TimeChanged;
+            mediaPlayerClock.CurrentGlobalSpeedInvalidated += MediaPlayer_TimeChanged;
 
             TimelineSlider.AddHandler(MouseLeftButtonUpEvent,
-                      new MouseButtonEventHandler(SliderInteractionFinished),
+                      new MouseButtonEventHandler(Slider_InteractionFinished),
                       true);
             TimelineSlider.AddHandler(MouseLeftButtonDownEvent,
-                      new MouseButtonEventHandler(SliderInteractionStarted),
+                      new MouseButtonEventHandler(Slider_InteractionStarted),
                       true);
 
             // If file path is long, trim it
@@ -362,7 +362,7 @@ namespace VideoTrimmer
         }
 
         // This is updated when the timeline is changed.
-        private void MediaPlayer_OnTimeChanged(object sender, EventArgs e)
+        private void MediaPlayer_TimeChanged(object sender, EventArgs e)
         {
             // Prevent audio popping if the slider is being manually moved.
             MediaPlayer.Volume = isManipulatingTimelineSlider ? 0.0 : cachedMediaVolume;
@@ -391,8 +391,8 @@ namespace VideoTrimmer
         }
 
         // User interaction - button clicked
-        private void OnJumpToStartMarkerButtonPressed(object sender, RoutedEventArgs e) => JumpToMarker(timeMarkerStart);
-        private void OnJumpToEndMarkerButtonPressed(object sender, RoutedEventArgs e) => JumpToMarker(timeMarkerEnd);
+        private void JumpToStartMarker_ButtonPressed(object sender, RoutedEventArgs e) => JumpToMarker(timeMarkerStart);
+        private void JumpToEndMarker_ButtonPressed(object sender, RoutedEventArgs e) => JumpToMarker(timeMarkerEnd);
 
         private void JumpToMarker(TimeCodeWrapper timeMarker)
         {
@@ -403,7 +403,7 @@ namespace VideoTrimmer
         }
 
         // User interaction - button clicked
-        private void OnPlayPauseButtonClicked(object sender, RoutedEventArgs e)
+        private void PlayPause_ButtonPressed(object sender, RoutedEventArgs e)
         {
             if (mediaPlayerTimeline.Source == null) return;
 
@@ -456,7 +456,7 @@ namespace VideoTrimmer
         }
 
         // User clicked on the slider, so let's disable automatic slider updates
-        private void SliderInteractionStarted(object sender, MouseButtonEventArgs e)
+        private void Slider_InteractionStarted(object sender, MouseButtonEventArgs e)
         {
             isManipulatingTimelineSlider = true;
 
@@ -468,7 +468,7 @@ namespace VideoTrimmer
         }
 
         // User changed the slider value.
-        private void SliderValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void Slider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             // Early out if slider was moved automatically due to video playback.
             if (!isManipulatingTimelineSlider)
@@ -480,7 +480,7 @@ namespace VideoTrimmer
         }
 
         // User finished interaction with the slider.
-        private void SliderInteractionFinished(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private void Slider_InteractionFinished(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             if (wasPlayingWhenSliderChanged)
             {

--- a/TimeCodeWrapper.cs
+++ b/TimeCodeWrapper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows.Controls;
+
+namespace VideoTrimmer
+{
+    public class TimeCodeWrapper
+    {
+        public bool IsStartMarker { get; private set; }
+        public TextBox TextBox { get; private set; }
+        public Button ButtonSet { get; private set; }
+        public Button ButtonJumpTo { get; private set; }
+        public TimeSpan? CurrentTime { get; private set; }
+
+        public TimeCodeWrapper(TextBox textBox, Button buttonSet, Button buttonJumpTo, bool isStartMarker)
+        {
+            TextBox = textBox;
+            ButtonSet = buttonSet;
+            ButtonJumpTo = buttonJumpTo;
+            IsStartMarker = isStartMarker;
+
+            SetTimeSpan(null);
+        }
+
+        public void SetTimeSpan(TimeSpan? timeSpan)
+        {
+            CurrentTime = timeSpan;
+            TextBox.Text = CurrentTime.HasValue ? CurrentTime.Value.ToString(Globals.timeFormat) : "N/A";
+            ButtonSet.IsEnabled = CurrentTime.HasValue;
+            ButtonJumpTo.IsEnabled = CurrentTime.HasValue;
+        }
+
+        public void SetLockStatus(bool newLockStatus)
+        {
+            TextBox.IsEnabled = newLockStatus;
+            ButtonSet.IsEnabled = newLockStatus;
+            ButtonJumpTo.IsEnabled = !newLockStatus;
+            CurrentTime = null;
+        }
+    }
+}

--- a/VideoTrimmer.csproj
+++ b/VideoTrimmer.csproj
@@ -81,6 +81,7 @@
     <Compile Include="ProgressWindow.xaml.cs">
       <DependentUpon>ProgressWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TimeCodeWrapper.cs" />
     <Compile Include="VideoProcessing.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
![2022-02-13 16_09_20-Video Trimmer DEBUG](https://user-images.githubusercontent.com/7767772/153759593-dde965b6-a2a8-470a-9c3d-8d79397c7a61.png)

- Allowed video preview to be updated when slider is moving. (Previously it would only update after slider was released which made it difficult to accurately choose a frame.)
- Added buttons to go to start/end markers.
- Added current time under video.
- Fixed inaccurate start/end markers by using TimeSpans directly instead of using string formatting. This fixes the issue where the trimmed video would not be frame-accurate.
- Changed timecode format from hh:mm:ss to hh:mm:ss:ff.
- Allow timecode for start/end markers to be updated when Enter is pressed.
- Added "Pause at end marker" checkbox to make it easier to visualize when the trimmed video will end.
- Made window larger.